### PR TITLE
Remove .defaults from django url imports

### DIFF
--- a/beta/urls.py
+++ b/beta/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 from beta.views import Signup, Confirmation
 


### PR DESCRIPTION
Fixes an import error for me on Django 1.8
