### PR TITLE
Test against Python 3.15

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,6 +22,8 @@ jobs:
           - "3.13"
           - "3.14"
           - "3.14t"
+          - "3.15"
+          - "3.15t"
         django-version:
           - "4.2"  # LTS
           - "5.1"
@@ -50,6 +52,15 @@ jobs:
             django-version: "5.1"
           - python-version: "3.14t"
             django-version: "5.1"
+          # Django 4.2 and 5.1 are not compatible with Python 3.15 either
+          - python-version: "3.15"
+            django-version: "4.2"
+          - python-version: "3.15t"
+            django-version: "4.2"
+          - python-version: "3.15"
+            django-version: "5.1"
+          - python-version: "3.15t"
+            django-version: "5.1"
 
     steps:
       - uses: actions/checkout@v4
@@ -58,6 +69,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          # 3.15 has no final release yet. Harmless for the others, and can be
+          # dropped once 3.15 ships.
+          allow-prereleases: true
 
       - name: Install dependencies
         run: |

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 DJANGO_VERSIONS = ["4.2", "5.1", "5.2", "6.0", "6.1"]
-PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
 
 # Django versions that have no final release yet need a specifier that opts in
 # to pre-releases. Naming the pre-release also lets the same spec pick up the
@@ -19,6 +19,11 @@ INVALID_PYTHON_DJANGO_SESSIONS = [
     ("3.14", "5.1"),
     ("3.14t", "4.2"),
     ("3.14t", "5.1"),
+    # Django 4.2 and 5.1 are not compatible with Python 3.15 either
+    ("3.15", "4.2"),
+    ("3.15", "5.1"),
+    ("3.15t", "4.2"),
+    ("3.15t", "5.1"),
 ]
 
 nox.options.default_venv_backend = "uv|venv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Free Threading :: 3 - Stable",
 ]
 dependencies = []


### PR DESCRIPTION
3.15 is at beta 3, with the final release due in October, so this adds it to
the matrix and publishes the trove classifier without promising support yet. The
free-threaded build (3.15t) goes in alongside it, the same way 3.14t did.

Django 4.2 and 5.1 do not work on 3.15, exactly as on 3.14, so the same
exclusions are added to both the workflow and the noxfile. 5.2, 6.0, and 6.1 all
pass.

setup-python needs allow-prereleases while 3.15 has no final release. That flag
is harmless for the other versions and can be dropped once 3.15 ships.

Tested locally with nox on 3.15 + Django 6.1.